### PR TITLE
fix(attrs): dynamic attributes.

### DIFF
--- a/src/borkdude/html.cljc
+++ b/src/borkdude/html.cljc
@@ -51,7 +51,8 @@
      (->attrs opts m))))
 
 (defn- compile-attrs [opts m]
-  (if (contains? m :&)
+  (if (or (contains? m :&)
+          (some #(-> % second seq?) m)) 
     `(->attrs ~opts ~(get m :&) ~(dissoc m :&))
     (->attrs opts m)))
 


### PR DESCRIPTION
Hello,

This seems to work well for me but I figured this was to simple and there may be an edge case I'm not 
considering.

Essentially, it's just looking for a quoted list in the values of the attributes. If it sees one, it uses the same logic if it had seen a ":&" attribute name. I'm submitting as a draft just to get your thoughts. 


fixes #3 

