### PR TITLE
Fix symbol-valued attributes rendering as their name instead of their value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Unreleased changes are available via `io.github.borkdude/html {:git/sha "..."}` 
 
 [html](https://github.com/borkdude/html): Produce HTML from hiccup in Clojure and ClojureScript
 
+## Unreleased
+
+- Fix symbol-valued attributes being rendered as their symbol name instead of their runtime value: `(let [x 1] (html [:div {:data-x x}]))` now yields `data-x="1"` rather than `data-x="x"`. Extends the dynamic-attribute support from [#3](https://github.com/borkdude/html/issues/3) to bare symbols and symbols nested in literal attribute collections.
+
 ## 0.2.3
 
 - Make `escape-html` public ([@kanwei](https://github.com/kanwei))

--- a/src/borkdude/html.cljc
+++ b/src/borkdude/html.cljc
@@ -50,8 +50,17 @@
    (let [m (merge base-map m)]
      (->attrs opts m))))
 
-(defn constant? [v]
-  (not (seq? v)))
+(defn constant?
+  "True when v is a literal whose value is known at macroexpansion time and can
+  therefore be folded into the attribute string at compile time. Symbols are
+  runtime references, not constants, so they (and any collection containing one)
+  must be deferred to a runtime `->attrs` call."
+  [v]
+  (cond
+    (symbol? v) false
+    (seq? v) false
+    (coll? v) (every? constant? v) ;; vectors/sets/maps (maps iterate their entries)
+    :else true))
 
 (defn- compile-attrs [opts m]
   (if (or (contains? m :&)

--- a/test/borkdude/html_test.cljc
+++ b/test/borkdude/html_test.cljc
@@ -77,12 +77,39 @@
     "<a href=\"http://dude\"></a>"
     (html [:a {:href (str "http://" "dude")}])
 
+    ;; a symbol attribute value renders its runtime value, not its name
+    "<div data-id=\"main\"></div>"
+    (let [x "main"]
+      (html [:div {:data-id x}]))
+
+    ;; a symbol nested inside a literal attribute collection also renders its
+    ;; runtime value (a case that `(str ...)` around the symbol cannot fix)
+    "<div style=\"color: red;\"></div>"
+    (let [c "red"]
+      (html [:div {:style {:color c}}]))
+
     "<div class=\"container\"></div>"
     (html [:div.container])
 
     "<a class=\"bar baz quux\" id=\"foo\"></a>"
     (html [:a#foo.bar.baz {:class "quux"}]))
   )
+
+(t/deftest symbol-attribute-values
+  ;; A bound symbol used as an attribute value must evaluate to its runtime
+  ;; value. Previously `constant?` treated symbols as compile-time constants,
+  ;; so the attribute map was folded at macroexpansion time and the symbol's
+  ;; *name* was emitted literally (e.g. data-id="x" instead of data-id="42").
+  (t/testing "simple: a top-level symbol attribute value"
+    (let [x 42]
+      (t/is (= "<div data-id=\"42\"></div>"
+               (str (html [:div {:data-id x}]))))))
+  (t/testing "complex: a symbol nested in a literal attribute collection"
+    ;; `(str c)` cannot rescue this case — the enclosing literal map is what
+    ;; gets folded, so the fix must recurse into collections.
+    (let [c "red"]
+      (t/is (= "<div style=\"color: red;\"></div>"
+               (str (html [:div {:style {:color c}}])))))))
 
 (t/deftest test-escaped-chars
   (t/is (= (escape-html "\"") "&quot;"))


### PR DESCRIPTION
This is a Claude code-generated PR, but the fix looks right to me. This issue has been bugging me for a while; it trips me up, but it trips Claude up more. It would be nice to clean this up.

PS thanks for this lib, I've really enjoyed it!

## Problem

A bound symbol used as an attribute value renders the symbol's **name** instead of its runtime value:

```clojure
(let [x 42] (html [:div {:data-id x}]))
;; => <div data-id="x"></div>      ✗  (want data-id="42")

(let [c "red"] (html [:div {:style {:color c}}]))
;; => <div style="color: c;"></div>  ✗  (want color: red;)
```

The first case has a known workaround — `(str x)` — but only by accident (it turns the value into a `seq?`). The second case (a symbol nested in a literal attribute collection) has **no** `(str ...)` workaround, because it's the enclosing literal map that gets folded.

By contrast, symbols used as element *children* already evaluate correctly, since children always go through the runtime `->safe` path. Only attribute values had this hole.

## Root cause

`compile-attrs` folds an attribute map into a string literal at macroexpansion time whenever every value is `constant?`. But:

```clojure
(defn constant? [v]
  (not (seq? v)))
```

A symbol is not a `seq?`, so it was treated as a compile-time constant. The macro then ran `->attrs` over the *unevaluated* form at compile time, and `->attrs` falls through to `:else (pr-str (str v))`, stringifying the symbol's name. Confirmed via macroexpansion:

```clojure
(macroexpand '(html [:div {:data-id x}]))
;; => (->Html (str "<div data-id=\"x\">" "</div>"))   ; x baked in as its name
```

This is the natural follow-on to #3, which added dynamic-value support for call forms (`{:a (+ 1 2 3)}`) but not for bare/nested symbols.

## Fix

Make `constant?` recognize symbols as runtime references, and recurse into collections so a symbol anywhere inside an attribute value defers the whole map to a runtime `->attrs` call:

```clojure
(defn constant? [v]
  (cond
    (symbol? v) false
    (seq? v)    false
    (coll? v)   (every? constant? v)
    :else       true))
```

Literal-only attribute maps still fold at compile time, so the existing optimization (and #3's behavior) is preserved. This is a macroexpansion-time change only — zero runtime cost.

## Tests

Added a dedicated `symbol-attribute-values` deftest covering the **simple** (top-level symbol) and **complex** (symbol nested in a literal collection) cases, plus two rows in the existing `ok` table. Verified the new tests **fail** on the old `constant?` (`data-id="x"`, `color: c;`) and pass with the fix, under both `clojure -X:test` and the CLJS runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)